### PR TITLE
Fixed URL for ColBERT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyterrier-colbert & ColBERT-PRF
 
-Advanced [PyTerrier](https://github.com/terrier-org/pyterrier) bindings for [ColBERT](https://github.com/stanford-futuredata/ColBERT/tree/v0.2), including for dense indexing and retrieval. This also includes the implementation of [ColBERT PRF](https://arxiv.org/abs/2106.11251). 
+Advanced [PyTerrier](https://github.com/terrier-org/pyterrier) bindings for [ColBERT](https://github.com/stanford-futuredata/ColBERT/), including for dense indexing and retrieval. This also includes the implementation of [ColBERT PRF](https://arxiv.org/abs/2106.11251). 
 
 ## Usage
 


### PR DESCRIPTION
Tiny fix. The URL for ColBERT was pointing to their older v0.2 branch. That's merged with Master now.