### PR TITLE
Make mask_punctuation configurable

### DIFF
--- a/pyterrier_colbert/faiss_term_index.py
+++ b/pyterrier_colbert/faiss_term_index.py
@@ -30,7 +30,7 @@ class Object(object):
 
 class FaissNNTerm():
 
-    def __init__(self, colbert, index_root, index_name, nprobe=10, partitions=None, part_range=None, query_maxlen=32, faiss_index=None, cf=True, df=False):
+    def __init__(self, colbert, index_root, index_name, nprobe=10, partitions=None, part_range=None, query_maxlen=32, faiss_index=None, cf=True, df=False, mask_punctuation=False):
         if type(colbert) == str:
             args = Object()
             args.checkpoint = colbert
@@ -38,7 +38,7 @@ class FaissNNTerm():
             args.similarity = 'cosine'
             args.query_maxlen = 32
             args.doc_maxlen = 180
-            args.mask_punctuation = False
+            args.mask_punctuation = mask_punctuation
             self.colbert, args.checkpoint = load_colbert(args)
         else:
             self.colbert = colbert

--- a/pyterrier_colbert/indexing.py
+++ b/pyterrier_colbert/indexing.py
@@ -259,13 +259,13 @@ class CollectionEncoder_Generator(CollectionEncoder):
 
 
 class ColBERTIndexer(IterDictIndexerBase):
-    def __init__(self, checkpoint, index_root, index_name, chunksize, prepend_title=False, num_docs=None, ids=True, gpu=True):
+    def __init__(self, checkpoint, index_root, index_name, chunksize, prepend_title=False, num_docs=None, ids=True, gpu=True, mask_punctuation=False):
         args = Object()
         args.similarity = 'cosine'
         args.dim = 128
         args.query_maxlen = 32
         args.doc_maxlen = 180
-        args.mask_punctuation = False
+        args.mask_punctuation = mask_punctuation
         args.checkpoint = checkpoint
         args.bsize = 128
         args.collection = None
@@ -303,7 +303,8 @@ class ColBERTIndexer(IterDictIndexerBase):
             self.args.index_root,
             self.args.index_name,
             self.args.partitions,
-            memtype, gpu=self.gpu
+            memtype, gpu=self.gpu,
+            mask_punctuation=self.args.mask_punctuation
         )
 
     def index(self, iterator):

--- a/pyterrier_colbert/ranking.py
+++ b/pyterrier_colbert/ranking.py
@@ -215,7 +215,7 @@ class re_ranker_mmap:
 class ColBERTModelOnlyFactory():
 
     def __init__(self, 
-            colbert_model : Union[str, Tuple[colbert.modeling.colbert.ColBERT, dict]], gpu=True):
+            colbert_model : Union[str, Tuple[colbert.modeling.colbert.ColBERT, dict]], gpu=True, mask_punctuation=False):
         args = Object()
         args.query_maxlen = 32
         args.doc_maxlen = 180
@@ -226,7 +226,7 @@ class ColBERTModelOnlyFactory():
         args.amp = True
         args.nprobe = 10
         args.part_range = None
-        args.mask_punctuation = False
+        args.mask_punctuation = mask_punctuation
 
         self.gpu = True
         if not gpu:
@@ -500,9 +500,10 @@ class ColBERTFactory(ColBERTModelOnlyFactory):
             faiss_partitions=None,#TODO 100-
             memtype = "mem",
             faisstype= "mem",
-            gpu=True):
+            gpu=True,
+            mask_punctuation=False):
         
-        super().__init__(colbert_model, gpu=gpu)
+        super().__init__(colbert_model, gpu=gpu, mask_punctuation=mask_punctuation)
        
         self.verbose = False
         self._faissnn = None
@@ -608,7 +609,7 @@ class ColBERTFactory(ColBERTModelOnlyFactory):
             self.index_root,
             self.index_name,
             faiss_index = self._faiss_index(), 
-            cf=cf, df=df)
+            cf=cf, df=df, mask_punctuation=self.args.mask_punctuation)
         return self._faissnn
 
     def _faiss_index(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-terrier>=0.5.0
 pandas
 torch>=1.6.0
-git+https://github.com/cmacdonald/ColBERT.git@v0.2#egg=ColBERT
+git+https://github.com/Yaasha/ColBERT.git@v0.2#egg=ColBERT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-terrier>=0.5.0
 pandas
 torch>=1.6.0
-git+https://github.com/Yaasha/ColBERT.git@v0.2#egg=ColBERT
+git+https://github.com/cmacdonald/ColBERT.git@v0.2#egg=ColBERT

--- a/tests/test_mask_punctuation.py
+++ b/tests/test_mask_punctuation.py
@@ -10,24 +10,27 @@ class TestMaskPunctuation(unittest.TestCase):
         mof = ColBERTModelOnlyFactory(CHECKPOINT, gpu=False, mask_punctuation=True)
         inference = mof.args.inference
         self.assertTrue(len(inference.colbert.skiplist) > 0)
-        embs, ids = inference.docFromText(["bottom. --Lynne @ Lynne Marie Studios, Inc."], bsize=8, with_ids=True, keep_dims=False)
-        # [(3953, 'bottom'),
-        # (1012, '.'), REMOVED
-        # (1011, '-'), REMOVED
-        # (1011, '-'), REMOVED
-        # (26938, 'lynne'),
-        # (1030, '@'), REMOVED
-        # (26938, 'lynne'),
-        # (5032, 'marie'),
-        # (4835, 'studios'),
-        # (1010, ','), REMOVED
-        # (4297, 'inc'),
-        # (1012, '.')] REMOVED
-        # 6 KEPT
-        expected_ids = [101, 2] + [3953, 26938, 26938, 5032, 4835, 4297] + [102]
-        self.assertEqual(len(ids[0].tolist()), len(expected_ids))
-        self.assertTrue(ids[0].tolist() == expected_ids)
-        self.assertEqual(embs[0].shape[0], len(expected_ids))
+
+        for bsize in [8, None]:
+            with self.subTest(bsize=bsize):
+                embs, ids = inference.docFromText(["bottom. --Lynne @ Lynne Marie Studios, Inc.", "a short doc"], bsize=bsize, with_ids=True, keep_dims=False)
+                # [(3953, 'bottom'),
+                # (1012, '.'), REMOVED
+                # (1011, '-'), REMOVED
+                # (1011, '-'), REMOVED
+                # (26938, 'lynne'),
+                # (1030, '@'), REMOVED
+                # (26938, 'lynne'),
+                # (5032, 'marie'),
+                # (4835, 'studios'),
+                # (1010, ','), REMOVED
+                # (4297, 'inc'),
+                # (1012, '.')] REMOVED
+                # 6 KEPT
+                expected_ids = [101, 2] + [3953, 26938, 26938, 5032, 4835, 4297] + [102]
+                #self.assertEqual(len(ids[0].tolist()), len(expected_ids))
+                # we ignore the ids after len(expected_ids) as they can be 0.
+                self.assertTrue(ids[0][0:len(expected_ids)].tolist() == expected_ids)
     
     def test_nomask_punctuation_tokenisation(self):
         import pyterrier as pt
@@ -35,23 +38,25 @@ class TestMaskPunctuation(unittest.TestCase):
         mof = ColBERTModelOnlyFactory(CHECKPOINT, gpu=False, mask_punctuation=False)
         inference = mof.args.inference
         self.assertTrue(len(inference.colbert.skiplist) == 0)
-        embs, ids = inference.docFromText(["bottom. --Lynne @ Lynne Marie Studios, Inc."], bsize=8, with_ids=True, keep_dims=False)
-        # [(3953, 'bottom'),
-        # (1012, '.'),
-        # (1011, '-'),
-        # (1011, '-'),
-        # (26938, 'lynne'),
-        # (1030, '@'),
-        # (26938, 'lynne'),
-        # (5032, 'marie'),
-        # (4835, 'studios'),
-        # (1010, ','),
-        # (4297, 'inc'),
-        # (1012, '.')]
-        expected_ids = [101, 2] + [3953, 1012, 1011, 1011, 26938, 1030, 26938, 5032, 4835, 1010, 4297, 1012] + [102]
-        self.assertEqual(len(ids[0].tolist()), len(expected_ids))
-        self.assertTrue(ids[0].tolist() == expected_ids)
-        self.assertEqual(embs[0].shape[0], len(expected_ids))
+        for bsize in [8, None]:
+            with self.subTest(bsize=bsize):
+                embs, ids = inference.docFromText(["bottom. --Lynne @ Lynne Marie Studios, Inc.", "a short doc"], bsize=bsize, with_ids=True, keep_dims=False)
+                # [(3953, 'bottom'),
+                # (1012, '.'),
+                # (1011, '-'),
+                # (1011, '-'),
+                # (26938, 'lynne'),
+                # (1030, '@'),
+                # (26938, 'lynne'),
+                # (5032, 'marie'),
+                # (4835, 'studios'),
+                # (1010, ','),
+                # (4297, 'inc'),
+                # (1012, '.')]
+                expected_ids = [101, 2] + [3953, 1012, 1011, 1011, 26938, 1030, 26938, 5032, 4835, 1010, 4297, 1012] + [102]
+                self.assertEqual(len(ids[0].tolist()), len(expected_ids))
+                self.assertTrue(ids[0].tolist() == expected_ids)
+                self.assertEqual(embs[0].shape[0], len(expected_ids))
 
 
     def test_mask_punctuation_scoring(self):

--- a/tests/test_mask_punctuation.py
+++ b/tests/test_mask_punctuation.py
@@ -1,0 +1,60 @@
+import unittest
+import tempfile
+
+CHECKPOINT="http://www.dcs.gla.ac.uk/~craigm/colbert.dnn.zip"
+class TestMaskPunctuation(unittest.TestCase):
+
+    def test_mask_punctuation_scoring(self):
+        import pyterrier as pt
+        from pyterrier_colbert.indexing import ColBERTIndexer
+
+        index_root = self.test_dir
+
+        iter = pt.get_dataset("vaswani").get_corpus_iter()
+        to_index = [next(iter) for i in range(200) ] + [{"docno": "a", "text": "bottom. --Lynne @ Lynne Marie Studios, Inc."}]
+        query = "Can anyone tell me the dimensions of this pot? Is clear top glass? ASAP, please?"
+
+        # indexing without ids and with masking
+        indexer = ColBERTIndexer(
+            CHECKPOINT, 
+            index_root, "no_ids", 
+            chunksize=3,
+            gpu=False,
+            mask_punctuation=True,
+            ids=False)
+        indexer.index(to_index)
+        pytcolbert = indexer.ranking_factory()
+        dense_e2e = pytcolbert.end_to_end()
+
+        no_ids = dense_e2e.search(query)
+        no_ids = no_ids[no_ids["docno"] == "a"].iloc[0]
+
+        # indexing with ids and with masking
+        indexer = ColBERTIndexer(
+            CHECKPOINT, 
+            index_root, "with_ids", 
+            chunksize=3,
+            gpu=False,
+            mask_punctuation=True,
+            ids=True)
+        indexer.index(to_index)
+        pytcolbert = indexer.ranking_factory()
+        dense_e2e = pytcolbert.end_to_end()
+
+        with_ids = dense_e2e.search(query)
+        with_ids = with_ids[with_ids["docno"] == "a"].iloc[0]
+
+        assert with_ids["score"] == no_ids["score"]
+
+    def setUp(self):
+        import pyterrier as pt
+        if not pt.started():
+            pt.init()
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        try:
+            shutil.rmtree(self.test_dir)
+        except:
+            pass


### PR DESCRIPTION
Add optional mask_punctuation parameter to pass to the ColBERT model. Also added test case for scoring using mask_punctuation=True and with_ids=True that caused issues in the past.