### PR TITLE
Added Handling for empty Passages

### DIFF
--- a/pyterrier_colbert/indexing.py
+++ b/pyterrier_colbert/indexing.py
@@ -159,8 +159,7 @@ class CollectionEncoder():
             pid, passage, *other = line_parts
 
             if len(passage) == 0:
-                print("Skipping empty passage at %d" % line_idx)
-                continue
+                raise ValueError("There is an empty passage at %d. Aborting... " % line_idx )
 
             if len(other) >= 1:
                 title, *_ = other
@@ -250,8 +249,7 @@ class CollectionEncoder_Generator(CollectionEncoder):
                 passage = title + ' | ' + passage
                 
             if len(passage) == 0:
-                print("Skipping empty passage at %d" % line_idx)
-                continue
+                raise ValueError("There is an empty passage at %d. Aborting... " % line_idx )
             
             batch.append(passage)
 

--- a/pyterrier_colbert/indexing.py
+++ b/pyterrier_colbert/indexing.py
@@ -164,7 +164,7 @@ class CollectionEncoder():
 
             pid, passage, *other = line_parts
 
-            if len(passage) == 0:
+            if len(passage) == 0 or passage.isspace():
                 raise ValueError("There is an empty passage at %d. Aborting... " % line_idx )
 
             if len(other) >= 1:
@@ -254,7 +254,7 @@ class CollectionEncoder_Generator(CollectionEncoder):
                 title = line["title"]
                 passage = title + ' | ' + passage
                 
-            if len(passage) == 0:
+            if len(passage) == 0 or passage.isspace():
                 raise ValueError("There is an empty passage at %d. Aborting... " % line_idx )
             
             batch.append(passage)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -84,6 +84,21 @@ class TestIndexing(unittest.TestCase):
     # def test_indexing_1doc_half(self):
     #     self._indexing_1doc('half')
 
+    def indexing_docnos_correctly(self):
+        #A test case to see whether empty passages are handled correctly. 
+        import pyterrier as pt
+        from pyterrier_colbert.indexing import ColBERTIndexer
+       
+        import os
+        indexer = ColBERTIndexer(
+            CHECKPOINT, 
+            os.path.dirname(self.test_dir),os.path.basename(self.test_dir), 
+            chunksize=3,
+            gpu=False)
+        corpus = [{ "docno" : "d%d" %i, "text": "mock documents mock documents mock documentsmock documentsmock documents mock documents mock documents mock documents mock documents mock documents mock documents mock documents mock documents "+str(i) } for i in range(150)]  + [{"docno": "empty", "text":""}] +  [{ "docno" : "d%d" %(i+150), "text": "mock document of clusters (100) " + str(i) } for i in range(150)]
+        with self.assertRaises(ValueError):
+            indexer.index(corpus)
+            
     def indexing_empty(self):
         #minimum test case size is 100 docs, 40 Wordpiece tokens, and nx > k. we found 200 worked
         import pyterrier as pt

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -86,7 +86,7 @@ class TestIndexing(unittest.TestCase):
     # def test_indexing_1doc_half(self):
     #     self._indexing_1doc('half')
 
-    def indexing_docnos_correctly(self):
+    def indexing_docnos_correctly_empty(self):
         #A test case to see whether empty passages are handled correctly. 
         import pyterrier as pt
         from pyterrier_colbert.indexing import ColBERTIndexer
@@ -98,6 +98,21 @@ class TestIndexing(unittest.TestCase):
             chunksize=3,
             gpu=False)
         corpus = [{ "docno" : "d%d" %i, "text": "mock documents mock documents mock documentsmock documentsmock documents mock documents mock documents mock documents mock documents mock documents mock documents mock documents mock documents "+str(i) } for i in range(150)]  + [{"docno": "empty", "text":""}] +  [{ "docno" : "d%d" %(i+150), "text": "mock document of clusters (100) " + str(i) } for i in range(150)]
+        with self.assertRaises(ValueError):
+            indexer.index(corpus)
+
+    def indexing_docnos_correctly_spaces(self):
+        #A test case to check whether passages only containing spaces are handled correctly. 
+        import pyterrier as pt
+        from pyterrier_colbert.indexing import ColBERTIndexer
+       
+        import os
+        indexer = ColBERTIndexer(
+            CHECKPOINT, 
+            os.path.dirname(self.test_dir),os.path.basename(self.test_dir), 
+            chunksize=3,
+            gpu=False)
+        corpus = [{ "docno" : "d%d" %i, "text": "mock documents mock documents mock documentsmock documentsmock documents mock documents mock documents mock documents mock documents mock documents mock documents mock documents mock documents "+str(i) } for i in range(150)]  + [{"docno": "empty", "text":"  "}] +  [{ "docno" : "d%d" %(i+150), "text": "mock document of clusters (100) " + str(i) } for i in range(150)]
         with self.assertRaises(ValueError):
             indexer.index(corpus)
             


### PR DESCRIPTION
If there are empty passages, we raise an ValueError in indexing.py instead of just printing a warning. 

There is a new TestCase that checks whether this is executed correctly. 