### PR TITLE
fix num of partitions and faiss index file name pattern matching

### DIFF
--- a/pyterrier_colbert/indexing.py
+++ b/pyterrier_colbert/indexing.py
@@ -259,7 +259,7 @@ class CollectionEncoder_Generator(CollectionEncoder):
 
 
 class ColBERTIndexer(pt.Indexer):
-    def __init__(self, checkpoint, index_root, index_name, chunksize, prepend_title=False, num_docs=None, ids=True, gpu=True, mask_punctuation=False):
+    def __init__(self, checkpoint, index_root, index_name, chunksize, num_partitions=None, prepend_title=False, num_docs=None, ids=True, gpu=True, mask_punctuation=False):
         args = Object()
         args.similarity = 'cosine'
         args.dim = 128
@@ -278,7 +278,7 @@ class ColBERTIndexer(pt.Indexer):
         args.input_arguments = copy.deepcopy(args)
         args.nranks, args.distributed = distributed.init(args.rank)
         self.saver_queue = queue.Queue(maxsize=3)
-        args.partitions = 100
+        args.partitions = num_partitions
         args.prepend_title = False
         self.args = args
         self.args.sample = None
@@ -345,9 +345,7 @@ class ColBERTIndexer(pt.Indexer):
 
         if self.args.partitions is None:
             self.args.partitions = 1 << math.ceil(math.log2(8 * math.sqrt(num_embeddings)))
-            warn("You did not specify --partitions!")
-            warn("Default computation chooses", self.args.partitions,
-                        "partitions (for {} embeddings)".format(num_embeddings))
+            warn(f"Number of partitions for FAISS index is not specified\nDefaulting to {self.args.partitions} which is calculated by the following formula: 1 << math.ceil(math.log2(8 * math.sqrt(num_embeddings)))")
         index_faiss(self.args)
         print("#> Faiss encoding complete")
         endtime = timer()


### PR DESCRIPTION
fix issue of number of partitions for the faiss indexing always being 100 and allow using faiss index files with names matching the pattern "ivfpq*.faiss"

Note that when indexing, FAISS may give a warning like this:
`WARNING clustering XXX points to YYY centroids`

This happens  when the sample being indexed has number of data points smaller or bigger than some number.
Apparently, the number of data points(n) must be in range of some multiples of the number of centroids(k). This warning can be silenced but I suppose the ColBERT repo might need an update for this.
More information can be found [here](https://github.com/facebookresearch/faiss/wiki/FAQ#can-i-ignore-warning-clustering-xxx-points-to-yyy-centroids).